### PR TITLE
fix(utility): make the utility public

### DIFF
--- a/.changeset/three-weeks-watch.md
+++ b/.changeset/three-weeks-watch.md
@@ -1,0 +1,5 @@
+---
+"@plainsheet/utility": patch
+---
+
+fix(utility): make the utility public

--- a/packages/utility/package.json
+++ b/packages/utility/package.json
@@ -7,7 +7,7 @@
     "typescript",
     "utility"
   ],
-  "private": true,
+  "private": false,
   "sideEffects": false,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Why?
to let users download the utility package when installing the react package.

## Description
