### PR TITLE
fix(core): Prevent dragging end handlers from being fired when the bo…

### DIFF
--- a/.changeset/silent-boats-look.md
+++ b/.changeset/silent-boats-look.md
@@ -1,0 +1,5 @@
+---
+"@plainsheet/core": patch
+---
+
+fix(core): Prevent dragging end handlers from being fired when the bo…

--- a/packages/core/src/event-handlers/dragging-handler.ts
+++ b/packages/core/src/event-handlers/dragging-handler.ts
@@ -190,17 +190,14 @@ export const handleDragEnd =
     const containerHeight = bottomSheetContainer.clientHeight;
 
     if (direction.isUp) {
+      if (!bottomSheetProps.expandable) {
+        return;
+      }
       const snapPointsInAsc = [...bottomSheetProps.snapPoints].sort(
         (left, right) => left - right
       );
 
       const containerVisibleHeight = containerHeight + -containerEndY;
-      if (
-        !bottomSheetProps.expandable &&
-        containerVisibleHeight >= containerHeight
-      ) {
-        return;
-      }
 
       for (const snapPoint of snapPointsInAsc) {
         // The diff between endY and startY can not be used because


### PR DESCRIPTION
## Why?
When `expandable` is `true`, the bottom sheet shouldn't be stretched up to the top of the viewport.

## Description
This PR fixes the incorrect condition to exit the bottom sheet's content expansion logic in the drag-end event handler.

Resolves https://github.com/plainsheet/plainsheet/issues/31
