### PR TITLE
fix(core, react): explicitly export only public APIs

### DIFF
--- a/.changeset/honest-horses-melt.md
+++ b/.changeset/honest-horses-melt.md
@@ -1,0 +1,6 @@
+---
+"@plainsheet/core": patch
+"@plainsheet/react": patch
+---
+
+Explicitly export only public APIs

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,12 +1,14 @@
-export * from "./bottom-sheet";
-export * from "./types";
+export { createBottomSheet } from "./bottom-sheet";
+export type {
+  BottomSheetCore,
+  BottomSheetCoreProps,
+  BottomSheetPosition,
+  DraggingAnimationTimings,
+  SnapPoints,
+} from "./types";
 
-export * from "./initializer";
+export { createPlaceholderBottomSheet } from "./initializer";
 
-export * from "./class-names/class-names";
-export * from "./class-names/selectors";
+export type { DraggingDirection } from "./calculator";
 
-export * from "./calculator";
-export * from "./class-names";
-
-export * from "./utils";
+export type { AnimationTimingPoints } from "./utils";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,3 @@
-export * from "./BottomSheet";
-export * from "./hooks";
+export { BottomSheet, createPlaceholderBottomSheet } from "./BottomSheet";
+export type { BottomSheetCore, BottomSheetProps } from "./BottomSheet";
+export { useBottomSheet } from "./hooks";


### PR DESCRIPTION
## Why?
Internal APIs should not be exported since they are subject to change. So, in this PR, I explicitly exported only documented public APIs.

## Description

Resolves https://github.com/plainsheet/plainsheet/issues/52