### PR TITLE
fix: prevent the handle from shrikning in a flex box

### DIFF
--- a/.changeset/eighty-rings-greet.md
+++ b/.changeset/eighty-rings-greet.md
@@ -1,0 +1,6 @@
+---
+"@plainsheet/core": patch
+"@plainsheet/react": patch
+---
+
+fix: prevent the handle from shrikning in a flex box

--- a/packages/core/src/style/pbs-handle.css
+++ b/packages/core/src/style/pbs-handle.css
@@ -4,6 +4,8 @@
   align-items: center;
   justify-content: center;
 
+  flex-shrink: 0;
+
   width: 100%;
   height: 30px;
   cursor: pointer;


### PR DESCRIPTION
## Why?
The handle should be large enough to be used. So it should not shrink when it is in a flex container.

## Description
